### PR TITLE
fix: correct permission query condition in Dashboard

### DIFF
--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -81,7 +81,7 @@ def get_permission_query_conditions(user):
 	if not allowed_modules:
 		return module_not_set
 
-	return f" `tabDashboard`.`module` in ({','.join(allowed_modules)}) or {module_not_set} "
+	return f" (`tabDashboard`.`module` in ({','.join(allowed_modules)}) or {module_not_set}) "
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## **Description**

This PR fixes an issue in the `get_permission_query_conditions` function of Dashboard doctype where the SQL condition was missing parentheses. This could lead to incorrect logical evaluation when the query is combined with other conditions.

### **Problem**

The current implementation returns an SQL condition without parentheses:
return f" `tabDashboard`.`module` in ({','.join(allowed_modules)}) or {module_not_set} "

### **Solution**
return f" (`tabDashboard`.`module` in ({','.join(allowed_modules)}) or {module_not_set}) "

### **Impact**

- Correctness: Ensures that the permission logic is evaluated correctly.
- Maintainability: Makes the query easier to understand and maintain.
- Reliability: Prevents potential bugs in dashboard filtering.

### **Example Scenario**

Imagine a user has access to Module1 and Module2. Without parentheses, a query like:
`tabDashboard`.`module` IN ('Module1', 'Module2') OR ifnull(`tabDashboard`.`module`, '') = '' AND `tabDashboard`.`is_active` = 1

Would be evaluated as:
(`tabDashboard`.`module` IN ('Module1', 'Module2') OR ifnull(`tabDashboard`.`module`, '') = '') AND `tabDashboard`.`is_active` = 1

With the fix, the logical grouping is preserved, and the query works as intended.

### **Checklist**

- All tests pass locally (UI and Unit tests).
- All business logic and validations are on the server-side.
- Updated necessary documentation (if applicable).
- PR name follows the [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html).

### **Additional Notes**

- This change is minimal and does not introduce any breaking changes.
- No screenshots/GIFs are included as this is a backend logic fix.

